### PR TITLE
Feature: Defer workflow execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export type { WorkflowDefinition } from "./workflow"
-export { executeWorkflowSerially, taskFnForWorkflow } from "./workflow"
+export { buildSerialWorkflow, taskFnForWorkflow } from "./workflow"


### PR DESCRIPTION
The current implementation of `executeWorkflowSerially` is a bit difficult to use, because it runs immediately. This doesn't allow a user to set up event listeners before a workflow starts. 

I've renamed `executeWorkflowSerially` to be `buildSerialWorkflow` (I don't have strong opinions about the name), and updated it to return a `runWorkflow` function. I've also updated the test to use the new API.